### PR TITLE
Add basic Node.js login system

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "login-demo",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "express-session": "^1.17.3",
+    "bcrypt": "^5.1.1",
+    "sqlite3": "^5.1.6",
+    "ejs": "^3.1.9"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,87 @@
+import express from 'express';
+import session from 'express-session';
+import bcrypt from 'bcrypt';
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+const dbPromise = open({
+  filename: path.join(__dirname, 'db.sqlite'),
+  driver: sqlite3.Database
+});
+
+app.set('view engine', 'ejs');
+app.set('views', path.join(__dirname, 'views'));
+app.use(express.urlencoded({ extended: false }));
+app.use(session({
+  secret: 'secret-key',
+  resave: false,
+  saveUninitialized: false
+}));
+
+async function initDb() {
+  const db = await dbPromise;
+  await db.exec(`CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE,
+    password TEXT
+  )`);
+}
+
+app.get('/register', (req, res) => {
+  res.render('register');
+});
+
+app.post('/register', async (req, res) => {
+  const { username, password } = req.body;
+  const hash = await bcrypt.hash(password, 10);
+  try {
+    const db = await dbPromise;
+    await db.run(
+      'INSERT INTO users (username, password) VALUES (?, ?)',
+      username,
+      hash
+    );
+    res.redirect('/login');
+  } catch (err) {
+    res.status(400).send('User already exists');
+  }
+});
+
+app.get('/login', (req, res) => {
+  res.render('login');
+});
+
+app.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  const db = await dbPromise;
+  const user = await db.get('SELECT * FROM users WHERE username = ?', username);
+  if (user && await bcrypt.compare(password, user.password)) {
+    req.session.userId = user.id;
+    res.redirect('/');
+  } else {
+    res.status(401).send('Invalid credentials');
+  }
+});
+
+app.get('/logout', (req, res) => {
+  req.session.destroy(() => {
+    res.redirect('/login');
+  });
+});
+
+app.get('/', async (req, res) => {
+  if (!req.session.userId) return res.redirect('/login');
+  const db = await dbPromise;
+  const user = await db.get('SELECT username FROM users WHERE id = ?', req.session.userId);
+  res.render('index', { user });
+});
+
+initDb().then(() => {
+  app.listen(3000, () => console.log('Server running on http://localhost:3000'));
+});

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,0 +1,3 @@
+<% layout('layout') -%>
+<h1>Welcome, <%= user.username %></h1>
+<a href="/logout">Logout</a>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title><%= title %></title>
+</head>
+<body>
+  <%- body %>
+</body>
+</html>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,0 +1,14 @@
+<% layout('layout') -%>
+<form action="/login" method="post">
+  <h1>Login</h1>
+  <div>
+    <label>Username:</label>
+    <input type="text" name="username" required>
+  </div>
+  <div>
+    <label>Password:</label>
+    <input type="password" name="password" required>
+  </div>
+  <button type="submit">Login</button>
+</form>
+<a href="/register">Register</a>

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -1,0 +1,14 @@
+<% layout('layout') -%>
+<form action="/register" method="post">
+  <h1>Register</h1>
+  <div>
+    <label>Username:</label>
+    <input type="text" name="username" required>
+  </div>
+  <div>
+    <label>Password:</label>
+    <input type="password" name="password" required>
+  </div>
+  <button type="submit">Register</button>
+</form>
+<a href="/login">Login</a>


### PR DESCRIPTION
## Summary
- set up minimal Express server
- implement registration and login using sqlite and bcrypt
- add simple EJS views for register, login and home page
- refine the registration route and replace body-parser with Express's built-in urlencoding

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `node server.js` *(fails: cannot find module 'express' due to failed install)*

------
https://chatgpt.com/codex/tasks/task_e_685e94e9c29083338f8c5778087bcea0